### PR TITLE
Fix TS5011 in e2e tsconfig by setting explicit rootDir

### DIFF
--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "CommonJS",
     "moduleResolution": "Node",
+    "rootDir": ".",
     "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     "types": ["node", "mocha"]


### PR DESCRIPTION
## Summary
- CI's `bun run test:e2e` failed because WDIO's config parser (ts-node) hit TS5011 when loading `wdio.conf.ts` under TypeScript 6 — the inferred common source dir became `./helpers` from the helper import, which TS6 now requires to be explicit.
- Setting `"rootDir": "."` in `tests/e2e/tsconfig.json` anchors compilation at the e2e root and unblocks the config load.

## Test plan
- [x] Reproduce locally: `bunx wdio run tests/e2e/wdio.conf.ts` previously printed the TS5011 error twice and exited 1.
- [x] After the fix, the config loads cleanly and WDIO proceeds into `onPrepare` (mock server / Vite / app launch).
- [ ] CI: confirm the GitHub Actions `test:e2e` job now passes the config-load step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)