### PR TITLE
Add e2e tests for agent execution start/stop and success

### DIFF
--- a/tests/e2e/specs/agents/execution.spec.ts
+++ b/tests/e2e/specs/agents/execution.spec.ts
@@ -1,0 +1,76 @@
+import { navigateTo } from "../../helpers/app";
+import { mockResponse, resetMocks } from "../../helpers/mock";
+import { create } from "../../helpers/factory";
+
+const TASK_INPUT = 'textarea[placeholder="Describe a task for this agent…"]';
+const RUN_BUTTON = '[data-testid="agent-run-button"]';
+const STATUS = '[data-testid="execution-status"]';
+
+async function waitForStatus(expected: string, timeout = 5_000): Promise<void> {
+  await browser.waitUntil(
+    async () => (await $(STATUS).getText()) === expected,
+    { timeout, timeoutMsg: `Expected execution status to be "${expected}"` },
+  );
+}
+
+async function openSeededAgent(name: string): Promise<void> {
+  await create("api_key", { provider: "openai", key: "OPENAI_KEY" });
+  await create("agent", {
+    name,
+    agent_goal: "Greet the user.",
+    system_instructions: "You are a helpful assistant.",
+    model: "gpt-4o",
+  });
+
+  await navigateTo("agents");
+  await $(`h3=${name}`).click();
+  await $(RUN_BUTTON).waitForDisplayed({ timeout: 5_000 });
+}
+
+describe("Agent execution", () => {
+  afterEach(async () => {
+    await resetMocks();
+  });
+
+  it("transitions Idle → Running and aborts to Cancelled when Stop is clicked", async () => {
+    await mockResponse("/v1/models", "tests/e2e/fixtures/openai/models.json", {
+      provider: "openai",
+    });
+    await mockResponse("/v1/chat/completions", "tests/e2e/fixtures/openai/chat-completions.sse", {
+      provider: "openai",
+      contentType: "text/event-stream",
+      delayMs: 10_000,
+    });
+
+    await openSeededAgent("Stop Test Agent");
+    await waitForStatus("Idle");
+
+    await $(TASK_INPUT).setValue("Say hello!");
+    await $(RUN_BUTTON).click();
+
+    await waitForStatus("Running", 3_000);
+
+    // Same button toggles to Stop while running.
+    await $(RUN_BUTTON).click();
+
+    await waitForStatus("Cancelled", 3_000);
+  });
+
+  it("runs to Success when the model responds", async () => {
+    await mockResponse("/v1/models", "tests/e2e/fixtures/openai/models.json", {
+      provider: "openai",
+    });
+    await mockResponse("/v1/chat/completions", "tests/e2e/fixtures/openai/chat-completions.sse", {
+      provider: "openai",
+      contentType: "text/event-stream",
+    });
+
+    await openSeededAgent("Success Test Agent");
+    await waitForStatus("Idle");
+
+    await $(TASK_INPUT).setValue("Say hello!");
+    await $(RUN_BUTTON).click();
+
+    await waitForStatus("Success", 20_000);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `tests/e2e/specs/agents/execution.spec.ts`, mirroring the pattern in `scenarios/execution.spec.ts`.
- Covers the cancellation path (10s delayed mock → click Stop mid-flight → status `Cancelled`) and a non-delayed success path.
- Agents previously had list/CRUD coverage only — this is the first execution-level e2e for them.

## Test plan
- [x] `bun run test:e2e -- --spec ./tests/e2e/specs/agents/execution.spec.ts` → 2 passing (1.7s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)