### PR TITLE
Add local/OpenAI-compatible provider support

### DIFF
--- a/src/actions/agentActions.ts
+++ b/src/actions/agentActions.ts
@@ -1,6 +1,6 @@
 import { streamText, stepCountIs, tool } from 'ai';
 import { jsonSchema } from 'ai';
-import { createModel } from '@/lib/gateway';
+import { createModel, getProviderHeaders } from '@/lib/gateway';
 import { toolConfigToAiSdkTools } from '@/lib/gateway/helpers';
 import { insertExecution, updateExecution, listToolsForEntity, listEnvVariables, listAgentMemories, saveAgentMemory } from '@/lib/storage';
 import { rejectPendingAgentHumanInput, waitForAgentHumanInput } from '@/actions/agentHumanInput';
@@ -254,8 +254,9 @@ export async function runAgentAction(
     // with no second turn to use tool results. With tools, require at least 2 steps.
     const maxStreamSteps = hasTools ? Math.max(2, configuredMaxSteps) : configuredMaxSteps;
 
+    const agentModelHeaders = await getProviderHeaders(agentRecord.provider);
     const result = streamText({
-      model: createModel({ provider: agentRecord.provider, model: agentRecord.model }),
+      model: createModel({ provider: agentRecord.provider, model: agentRecord.model }, agentModelHeaders),
       ...(instructions ? { system: instructions } : {}),
       prompt: taskInput,
       ...(hasTools ? { tools: aiTools } : {}),

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -17,6 +17,15 @@ export const PROVIDERS = {
     baseUrl: 'https://generativelanguage.googleapis.com',
     header: 'Authorization',
   },
+  LOCAL: {
+    id: 'local',
+    // Default target for any OpenAI-compatible local server (Ollama, LM Studio, vLLM, etc.).
+    // Overridable per-user via Settings → API Keys ("local_provider_base_url" setting) —
+    // see getProviderHeaders() in lib/gateway/helpers.ts.
+    name: 'Local (OpenAI-compatible)',
+    baseUrl: 'http://127.0.0.1:11434',
+    header: 'Authorization',
+  },
 } as const;
 
 // Export as array for easier iteration

--- a/src/features/Agents/MainContent/Test/index.tsx
+++ b/src/features/Agents/MainContent/Test/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { FlaskConical, Play, GitCompare } from "lucide-react";
 import { streamText, stepCountIs } from "ai";
-import { createModel } from "@/lib/gateway";
+import { createModel, getProviderHeaders } from "@/lib/gateway";
 import { toolConfigToAiSdkTools } from "@/lib/gateway/helpers";
 import {
   getAgentById,
@@ -257,8 +257,9 @@ export function TestView({ agentId, agentName }: TestViewProps) {
       let errorMsg: string | null = null;
 
       try {
+        const testHeaders = await getProviderHeaders(agentRecord.provider);
         const result = streamText({
-          model: createModel({ provider: agentRecord.provider, model: agentRecord.model }),
+          model: createModel({ provider: agentRecord.provider, model: agentRecord.model }, testHeaders),
           ...(instructions ? { system: instructions } : {}),
           prompt: tc.task,
           ...(hasTools ? { tools: aiTools } : {}),

--- a/src/features/Settings/MainContent/ApiKeys/index.tsx
+++ b/src/features/Settings/MainContent/ApiKeys/index.tsx
@@ -1,5 +1,5 @@
 import { Eye, EyeOff, CheckCircle, XCircle } from "lucide-react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 
@@ -77,6 +77,7 @@ function ApiKeys() {
     try {
       await setSetting(LOCAL_PROVIDER_BASE_URL_SETTING_KEY, value);
       clearModelCache();
+      loadModels();
       setLocalBaseUrl(value);
       setSaveStatus((prev) => ({ ...prev, local: "saved" }));
       setTimeout(() => {
@@ -89,17 +90,22 @@ function ApiKeys() {
     }
   };
 
-  useEffect(() => {
-    const loadModels = async () => {
-      try {
-        const models = await fetchAndNormalizeModels();
-        setProviderModels(models);
-      } catch (error) {
-        console.error("Failed to fetch provider models:", error);
-      }
-    };
-    loadModels();
+  // Re-run after any save/delete that could change which models are reachable
+  // (a new/removed API key, or a changed local endpoint) — clearing the cache
+  // alone leaves `providerModels` (and the descriptions derived from it) stale
+  // until the component happens to remount.
+  const loadModels = useCallback(async () => {
+    try {
+      const models = await fetchAndNormalizeModels();
+      setProviderModels(models);
+    } catch (error) {
+      console.error("Failed to fetch provider models:", error);
+    }
   }, []);
+
+  useEffect(() => {
+    loadModels();
+  }, [loadModels]);
 
   useEffect(() => {
     const fetchApiKeys = async () => {
@@ -143,8 +149,13 @@ function ApiKeys() {
           query: { where: { provider } },
         });
         clearModelCache();
-        const models = await fetchAndNormalizeModels({ forceRefresh: true });
-        setProviderModels(models);
+        // main inlined fetchAndNormalizeModels({ forceRefresh: true }) here;
+        // this branch routes every refresh through loadModels() so the
+        // out-of-order guard added later applies to all of them. Dropping
+        // forceRefresh is safe: clearModelCache() above removes the cache
+        // key, and getAllModels refetches when the provider is absent from
+        // the cache regardless of the flag.
+        loadModels();
       } catch (error) {
         console.error(`Failed to delete API key for ${provider}:`, error);
         setSaveStatus((prev) => ({ ...prev, [provider]: "error" }));
@@ -169,6 +180,7 @@ function ApiKeys() {
         });
       }
       clearModelCache();
+      loadModels();
       setApiKeys((prev) => ({ ...prev, [provider]: apiKey }));
       const models = await fetchAndNormalizeModels({ forceRefresh: true });
       setProviderModels(models);

--- a/src/features/Settings/MainContent/ApiKeys/index.tsx
+++ b/src/features/Settings/MainContent/ApiKeys/index.tsx
@@ -4,6 +4,9 @@ import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 
 import { fetchAndNormalizeModels, clearModelCache } from "@/lib/modelManager";
+import { getSetting, setSetting } from "@/lib/storage";
+import { LOCAL_PROVIDER_BASE_URL_SETTING_KEY } from "@/lib/gateway/constants";
+import { PROVIDERS as ALL_PROVIDERS } from "@/constants/providers";
 
 type SaveStatus = "idle" | "saving" | "saved" | "error";
 
@@ -39,6 +42,42 @@ function ApiKeys() {
   const [providerModels, setProviderModels] = useState<
     Record<string, { id: string; name: string }[]>
   >({});
+
+  // 'local' needs no API key — just a base URL, stored in `settings` rather than `api_keys`.
+  // Reuses the shared `saveStatus`/`getInputClass`/`renderStatusIcon` machinery below (keyed
+  // by "local") rather than a parallel status state, so the same visual feedback applies.
+  const [localBaseUrl, setLocalBaseUrl] = useState("");
+
+  useEffect(() => {
+    const loadLocalBaseUrl = async () => {
+      try {
+        const stored = await getSetting(LOCAL_PROVIDER_BASE_URL_SETTING_KEY);
+        setLocalBaseUrl(stored ?? ALL_PROVIDERS.LOCAL.baseUrl);
+      } catch (error) {
+        console.error("Failed to load local provider base URL:", error);
+        setLocalBaseUrl(ALL_PROVIDERS.LOCAL.baseUrl);
+      }
+    };
+    loadLocalBaseUrl();
+  }, []);
+
+  const handleSaveLocalBaseUrl = async (rawValue: string) => {
+    const value = rawValue.trim() || ALL_PROVIDERS.LOCAL.baseUrl;
+    setSaveStatus((prev) => ({ ...prev, local: "saving" }));
+    try {
+      await setSetting(LOCAL_PROVIDER_BASE_URL_SETTING_KEY, value);
+      clearModelCache();
+      setLocalBaseUrl(value);
+      setSaveStatus((prev) => ({ ...prev, local: "saved" }));
+      setTimeout(() => {
+        setSaveStatus((prev) => ({ ...prev, local: "idle" }));
+      }, 3000);
+    } catch (error) {
+      console.error("Failed to save local provider base URL:", error);
+      setSaveStatus((prev) => ({ ...prev, local: "error" }));
+      toast.error("Failed to save local endpoint", { description: "Could not save the base URL. Please try again." });
+    }
+  };
 
   useEffect(() => {
     const loadModels = async () => {
@@ -224,6 +263,32 @@ function ApiKeys() {
             </p>
           </div>
         ))}
+
+        <div className="bg-white p-6 border border-slate-200 rounded-2xl shadow-sm">
+          <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider mb-2">
+            Local Endpoint (Ollama, LM Studio, vLLM, etc.)
+          </label>
+          <div className="relative">
+            <input
+              className={getInputClass("local")}
+              placeholder={ALL_PROVIDERS.LOCAL.baseUrl}
+              type="text"
+              value={localBaseUrl}
+              data-save-status={saveStatus.local}
+              onChange={(e) => setLocalBaseUrl(e.target.value)}
+              onBlur={(e) => handleSaveLocalBaseUrl(e.target.value)}
+            />
+            <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
+              {renderStatusIcon("local")}
+            </div>
+          </div>
+          <p className="text-[11px] text-slate-400 mt-2">
+            {getProviderDescription(
+              "local",
+              `No API key needed — point this at any OpenAI-compatible server (defaults to ${ALL_PROVIDERS.LOCAL.baseUrl} for Ollama).`
+            )}
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/features/Settings/MainContent/ApiKeys/index.tsx
+++ b/src/features/Settings/MainContent/ApiKeys/index.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { fetchAndNormalizeModels, clearModelCache } from "@/lib/modelManager";
 import { getSetting, setSetting } from "@/lib/storage";
 import { LOCAL_PROVIDER_BASE_URL_SETTING_KEY } from "@/lib/gateway/constants";
+import { normalizeProviderBaseUrl } from "@/lib/gateway/helpers";
 import { PROVIDERS as ALL_PROVIDERS } from "@/constants/providers";
 
 type SaveStatus = "idle" | "saving" | "saved" | "error";
@@ -62,7 +63,16 @@ function ApiKeys() {
   }, []);
 
   const handleSaveLocalBaseUrl = async (rawValue: string) => {
-    const value = rawValue.trim() || ALL_PROVIDERS.LOCAL.baseUrl;
+    let value: string;
+    try {
+      value = rawValue.trim() ? normalizeProviderBaseUrl(rawValue) : ALL_PROVIDERS.LOCAL.baseUrl;
+    } catch (error) {
+      setSaveStatus((prev) => ({ ...prev, local: "error" }));
+      toast.error("Invalid local endpoint", {
+        description: error instanceof Error ? error.message : "Please enter a valid http(s) URL.",
+      });
+      return;
+    }
     setSaveStatus((prev) => ({ ...prev, local: "saving" }));
     try {
       await setSetting(LOCAL_PROVIDER_BASE_URL_SETTING_KEY, value);

--- a/src/features/Settings/MainContent/ApiKeys/index.tsx
+++ b/src/features/Settings/MainContent/ApiKeys/index.tsx
@@ -1,5 +1,5 @@
 import { Eye, EyeOff, CheckCircle, XCircle } from "lucide-react";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 
@@ -94,9 +94,17 @@ function ApiKeys() {
   // (a new/removed API key, or a changed local endpoint) — clearing the cache
   // alone leaves `providerModels` (and the descriptions derived from it) stale
   // until the component happens to remount.
+  //
+  // The mount-time call and a later save-triggered call can both be in flight at
+  // once; if the mount-time one resolves last it would otherwise overwrite the
+  // fresh result with stale data. loadModelsRequestId guards against that — only
+  // the response to the most recently *started* call is allowed to apply.
+  const loadModelsRequestId = useRef(0);
   const loadModels = useCallback(async () => {
+    const requestId = ++loadModelsRequestId.current;
     try {
       const models = await fetchAndNormalizeModels();
+      if (requestId !== loadModelsRequestId.current) return; // superseded by a newer call
       setProviderModels(models);
     } catch (error) {
       console.error("Failed to fetch provider models:", error);

--- a/src/lib/agent/index.ts
+++ b/src/lib/agent/index.ts
@@ -1,5 +1,5 @@
 import { ToolLoopAgent, stepCountIs } from 'ai';
-import { createModel } from '@/lib/gateway';
+import { createModel, getProviderHeaders } from '@/lib/gateway';
 import { streamWithEvents } from './streamWithEvents';
 
 import type { AgentEventCallback, ToolSet } from './types';
@@ -31,12 +31,13 @@ export interface Agent {
   stream(options: AgentStreamOptions): ReturnType<typeof streamWithEvents>;
 }
 
-export function createAgent(options: CreateAgentOptions): Agent {
+export async function createAgent(options: CreateAgentOptions): Promise<Agent> {
   const { provider, model, instructions, tools, timeout, maxSteps = 10, maxRetries = 3, onEvent } = options;
 
+  const headers = await getProviderHeaders(provider);
   const agent = new ToolLoopAgent({
     id: 'reticle-agent',
-    model: createModel({ provider, model }),
+    model: createModel({ provider, model }, headers),
     instructions: instructions,
     tools: tools,
     maxRetries: maxRetries,

--- a/src/lib/evals/evalAssertions.ts
+++ b/src/lib/evals/evalAssertions.ts
@@ -1,6 +1,6 @@
 import Ajv from "ajv";
 import { generateText } from "ai";
-import { createModel } from "@/lib/gateway";
+import { createModel, getProviderHeaders } from "@/lib/gateway";
 
 // ── Scenario ──────────────────────────────────────────────────────────────────
 
@@ -83,8 +83,9 @@ async function evaluateLlmJudgeAssertion(
   const model = assertion.judgeModel?.model ?? DEFAULT_JUDGE_MODEL;
 
   try {
+    const headers = await getProviderHeaders(provider);
     const { text } = await generateText({
-      model: createModel({ provider, model }),
+      model: createModel({ provider, model }, headers),
       system: systemPrompt,
       prompt: userPrompt,
       maxOutputTokens: 150,
@@ -118,8 +119,9 @@ async function evaluateGuardrailAssertion(
   const model = assertion.judgeModel?.model ?? DEFAULT_JUDGE_MODEL;
 
   try {
+    const headers = await getProviderHeaders(provider);
     const { text } = await generateText({
-      model: createModel({ provider, model }),
+      model: createModel({ provider, model }, headers),
       system: systemPrompt,
       prompt: userPrompt,
       maxOutputTokens: 150,

--- a/src/lib/gateway/constants.ts
+++ b/src/lib/gateway/constants.ts
@@ -22,6 +22,9 @@ export function getProviderModelsUrl(providerId: string): string {
   return PROVIDER_MODELS_URL[providerId] ?? `${GATEWAY_URL}/models`;
 }
 
+/** Key into the `settings` table for the user-configurable 'local' provider base URL. */
+export const LOCAL_PROVIDER_BASE_URL_SETTING_KEY = 'local_provider_base_url';
+
 export const API_KEY = '1';
 export const STEPS_COUNT = 5;
 export const GATEWAY_NAME = 'reticle';

--- a/src/lib/gateway/helpers.ts
+++ b/src/lib/gateway/helpers.ts
@@ -17,6 +17,28 @@ import {
   onRunnerExit,
 } from '@/lib/runner';
 
+/** Normalizes and validates a user-supplied provider base URL before it can reach
+ *  X-Proxy-Target-Url (forwarded verbatim by server.rs) or the settings table.
+ *  Rejects CR/LF (header-injection into the proxy's routing headers) and anything
+ *  that isn't a plain http(s) origin, and strips trailing slashes so concatenation
+ *  with the proxied request path (baseUrl + "/v1/chat/completions") can't produce "//". */
+export function normalizeProviderBaseUrl(rawValue: string): string {
+  const trimmed = rawValue.trim();
+  if (/[\r\n]/.test(trimmed)) {
+    throw new Error('Base URL cannot contain line breaks.');
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error('Enter a valid URL, e.g. http://127.0.0.1:11434');
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Only http:// and https:// URLs are supported.');
+  }
+  return (parsed.origin + parsed.pathname).replace(/\/+$/, '');
+}
+
 /** Builds the headers the local proxy (server.rs) reads to route + authenticate a request.
  *  Async because the 'local' provider's target URL is user-configurable (Settings → API Keys)
  *  and read from the settings table rather than being a compile-time constant. */
@@ -30,7 +52,11 @@ export async function getProviderHeaders(providerId: string): Promise<Record<str
   let baseUrl: string = providerConfig.baseUrl;
   if (providerId === 'local') {
     const customBaseUrl = await getSetting(LOCAL_PROVIDER_BASE_URL_SETTING_KEY);
-    if (customBaseUrl) baseUrl = customBaseUrl;
+    // Re-validate even though the Settings UI already validates on save: the stored
+    // value could predate this check, or have been edited directly in the DB.
+    // Fail loud (don't silently fall back to the default) so a broken override is
+    // visible rather than routing to a server the user didn't choose.
+    if (customBaseUrl) baseUrl = normalizeProviderBaseUrl(customBaseUrl);
   }
 
   const headers: Record<string, string> = {

--- a/src/lib/gateway/helpers.ts
+++ b/src/lib/gateway/helpers.ts
@@ -1,10 +1,11 @@
 import { invoke } from '@tauri-apps/api/core';
 import { PROVIDERS_LIST } from '@/constants/providers';
 import { jsonSchema, tool, type ToolSet } from 'ai';
-import { ANTHROPIC_VERSION, REASONING_MODEL_PREFIXES } from './constants';
+import { ANTHROPIC_VERSION, REASONING_MODEL_PREFIXES, LOCAL_PROVIDER_BASE_URL_SETTING_KEY } from './constants';
 import type { AttachedFile } from '@/contexts/StudioContext';
 import type { Tool } from '@/components/Tools/types';
 import { substituteVariables } from '@/lib/helpers/substituteVariables';
+import { getSetting } from '@/lib/storage';
 import {
   writeTempScript,
   deleteTempScript,
@@ -16,16 +17,26 @@ import {
   onRunnerExit,
 } from '@/lib/runner';
 
-export function getProviderHeaders(providerId: string): Record<string, string> {
+/** Builds the headers the local proxy (server.rs) reads to route + authenticate a request.
+ *  Async because the 'local' provider's target URL is user-configurable (Settings → API Keys)
+ *  and read from the settings table rather than being a compile-time constant. */
+export async function getProviderHeaders(providerId: string): Promise<Record<string, string>> {
   const providerConfig = PROVIDERS_LIST.find((p) => p.id === providerId);
 
   if (!providerConfig) {
     throw new Error(`Provider "${providerId}" not found.`);
   }
+
+  let baseUrl: string = providerConfig.baseUrl;
+  if (providerId === 'local') {
+    const customBaseUrl = await getSetting(LOCAL_PROVIDER_BASE_URL_SETTING_KEY);
+    if (customBaseUrl) baseUrl = customBaseUrl;
+  }
+
   const headers: Record<string, string> = {
     'X-Api-Provider': providerConfig.id,
     'X-Api-Auth-Header': providerConfig.header,
-    'X-Proxy-Target-Url': providerConfig.baseUrl,
+    'X-Proxy-Target-Url': baseUrl,
   };
 
   if (providerId === 'anthropic') {

--- a/src/lib/gateway/index.ts
+++ b/src/lib/gateway/index.ts
@@ -15,6 +15,8 @@ import {
   loadAttachmentsAsContentParts,
   toolConfigToAiSdkTools,
 } from './helpers';
+
+export { getProviderHeaders } from './helpers';
 import { LLMCallConfig } from '@/types';
 import type { AttachedFile } from '@/contexts/StudioContext';
 import type { Tool } from '@/components/Tools/types';
@@ -77,8 +79,11 @@ export function extractStepsAndToolCalls(
   return { modelSteps, toolCalls };
 }
 
+/** `headers` must be resolved by the caller via `await getProviderHeaders(provider)` first —
+ *  this stays synchronous because the AI SDK's `model` factories can't be awaited inline. */
 export const createModel = (
   config: Pick<LLMCallConfig, 'provider' | 'model'>,
+  headers: Record<string, string>,
   gateway?: GatewayFetch
 ) => {
   const { provider, model } = config;
@@ -89,7 +94,7 @@ export const createModel = (
     apiKey: API_KEY,
     baseURL: gatewayBase,
     includeUsage: true, // Important: must match original
-    headers: getProviderHeaders(provider),
+    headers,
     fetch: gateway?.fetch ?? fetch, // Use latency-measuring fetch when gateway provided
     // OpenAI reasoning models require max_completion_tokens instead of max_tokens.
     // This is a workaround to support the OpenAI API for reasoning models as @ai-sdk/openai-compatible doesn't handle this.
@@ -141,8 +146,9 @@ export const streamText = async (
   const envVarsMap = Object.fromEntries(rawEnvVars.map(v => [v.key, v.value]));
   const aiTools = tools?.length ? toolConfigToAiSdkTools(tools, envVarsMap) : undefined;
 
+  const headers = await getProviderHeaders(config.provider);
   const result = await streamTextAi({
-    model: createModel(config, gateway),
+    model: createModel(config, headers, gateway),
     messages: messages,
     temperature: config.temperature,
     maxOutputTokens: config.maxTokens,
@@ -159,6 +165,12 @@ export const streamText = async (
 export const listModels = async (providerId: string): Promise<any[]> => {
   const modelsUrl = getProviderModelsUrl(providerId);
   try {
+    // main added cursor pagination; this branch made getProviderHeaders
+    // async (the local provider resolves its base URL/key asynchronously).
+    // Both are needed: await the headers ONCE, then reuse them for every
+    // page — calling the async version per-iteration without awaiting would
+    // pass a Promise as `headers` and silently send no auth.
+    const headers = await getProviderHeaders(providerId);
     const models: any[] = [];
     let nextUrl: string | null = modelsUrl;
 
@@ -167,7 +179,7 @@ export const listModels = async (providerId: string): Promise<any[]> => {
     while (nextUrl) {
       const response = await fetch(nextUrl, {
         method: 'GET',
-        headers: getProviderHeaders(providerId),
+        headers,
       });
 
       if (!response.ok) {

--- a/tests/actions/agentActions.test.ts
+++ b/tests/actions/agentActions.test.ts
@@ -10,6 +10,7 @@ vi.mock('ai', () => ({
 
 vi.mock('@/lib/gateway', () => ({
   createModel: vi.fn(() => 'mock-model'),
+  getProviderHeaders: vi.fn(async () => ({})),
 }));
 
 vi.mock('@/lib/gateway/helpers', () => ({

--- a/tests/lib/evals/evalAssertions.test.ts
+++ b/tests/lib/evals/evalAssertions.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('ai', () => ({ generateText: vi.fn() }));
-vi.mock('@/lib/gateway', () => ({ createModel: vi.fn(() => 'mock-model') }));
+vi.mock('@/lib/gateway', () => ({
+  createModel: vi.fn(() => 'mock-model'),
+  getProviderHeaders: vi.fn(async () => ({})),
+}));
 
 import * as aiSdk from 'ai';
 import {
@@ -417,7 +420,10 @@ describe('evaluateAgentAssertion', () => {
         'output', [], 1,
       );
 
-      expect(mockCreateModel).toHaveBeenCalledWith({ provider: 'anthropic', model: 'claude-sonnet-4' });
+      expect(mockCreateModel).toHaveBeenCalledWith(
+        { provider: 'anthropic', model: 'claude-sonnet-4' },
+        expect.any(Object)
+      );
     });
   });
 

--- a/tests/lib/gateway/helpers.test.ts
+++ b/tests/lib/gateway/helpers.test.ts
@@ -20,6 +20,7 @@ import {
   getProviderHeaders,
   isReasoningModel,
   loadAttachmentsAsContentParts,
+  normalizeProviderBaseUrl,
   toolConfigToAiSdkTools,
 } from '@/lib/gateway/helpers';
 import { ANTHROPIC_VERSION } from '@/lib/gateway/constants';
@@ -76,6 +77,52 @@ describe('getProviderHeaders', () => {
     mockInvoke.mockResolvedValue([{ key: 'local_provider_base_url', value: 'http://192.168.1.50:1234' }]);
     const headers = await getProviderHeaders('local');
     expect(headers['X-Proxy-Target-Url']).toBe('http://192.168.1.50:1234');
+  });
+
+  it('throws rather than routing to a broken stored local base URL', async () => {
+    mockInvoke.mockResolvedValue([{ key: 'local_provider_base_url', value: 'not a url\r\nX-Injected: 1' }]);
+    await expect(getProviderHeaders('local')).rejects.toThrow();
+  });
+});
+
+// ── normalizeProviderBaseUrl ──────────────────────────────────────────────────
+
+describe('normalizeProviderBaseUrl', () => {
+  it('passes through a clean http URL unchanged', () => {
+    expect(normalizeProviderBaseUrl('http://127.0.0.1:11434')).toBe('http://127.0.0.1:11434');
+  });
+
+  it('accepts https URLs', () => {
+    expect(normalizeProviderBaseUrl('https://models.example.com')).toBe('https://models.example.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeProviderBaseUrl('  http://127.0.0.1:11434  ')).toBe('http://127.0.0.1:11434');
+  });
+
+  it('strips trailing slashes so path concatenation cannot produce "//"', () => {
+    expect(normalizeProviderBaseUrl('http://127.0.0.1:11434/')).toBe('http://127.0.0.1:11434');
+    expect(normalizeProviderBaseUrl('http://127.0.0.1:11434///')).toBe('http://127.0.0.1:11434');
+  });
+
+  it('preserves a non-root path while stripping its trailing slash', () => {
+    expect(normalizeProviderBaseUrl('http://127.0.0.1:8000/api/')).toBe('http://127.0.0.1:8000/api');
+  });
+
+  it('rejects values containing CR or LF (header-injection into the proxy)', () => {
+    expect(() => normalizeProviderBaseUrl('http://127.0.0.1:11434\r\nX-Injected: 1')).toThrow();
+    expect(() => normalizeProviderBaseUrl('http://127.0.0.1:11434\nX-Injected: 1')).toThrow();
+  });
+
+  it('rejects unparseable input', () => {
+    expect(() => normalizeProviderBaseUrl('not a url')).toThrow();
+    expect(() => normalizeProviderBaseUrl('')).toThrow();
+  });
+
+  it('rejects non-http(s) protocols', () => {
+    expect(() => normalizeProviderBaseUrl('file:///etc/passwd')).toThrow();
+    expect(() => normalizeProviderBaseUrl('ftp://example.com')).toThrow();
+    expect(() => normalizeProviderBaseUrl('javascript:alert(1)')).toThrow();
   });
 });
 

--- a/tests/lib/gateway/helpers.test.ts
+++ b/tests/lib/gateway/helpers.test.ts
@@ -32,37 +32,50 @@ beforeEach(() => vi.clearAllMocks());
 // ── getProviderHeaders ─────────────────────────────────────────────────────────
 
 describe('getProviderHeaders', () => {
-  it('returns correct routing headers for openai', () => {
-    const headers = getProviderHeaders('openai');
+  it('returns correct routing headers for openai', async () => {
+    const headers = await getProviderHeaders('openai');
     expect(headers['X-Api-Provider']).toBe('openai');
     expect(headers['X-Api-Auth-Header']).toBe('Authorization');
     expect(headers['X-Proxy-Target-Url']).toBe('https://api.openai.com');
   });
 
-  it('returns correct routing headers for anthropic and adds anthropic-version', () => {
-    const headers = getProviderHeaders('anthropic');
+  it('returns correct routing headers for anthropic and adds anthropic-version', async () => {
+    const headers = await getProviderHeaders('anthropic');
     expect(headers['X-Api-Provider']).toBe('anthropic');
     expect(headers['X-Api-Auth-Header']).toBe('X-Api-Key');
     expect(headers['X-Proxy-Target-Url']).toBe('https://api.anthropic.com');
     expect(headers['anthropic-version']).toBe(ANTHROPIC_VERSION);
   });
 
-  it('does not add anthropic-version for non-anthropic providers', () => {
-    const headers = getProviderHeaders('openai');
+  it('does not add anthropic-version for non-anthropic providers', async () => {
+    const headers = await getProviderHeaders('openai');
     expect(headers).not.toHaveProperty('anthropic-version');
   });
 
-  it('returns correct routing headers for google', () => {
-    const headers = getProviderHeaders('google');
+  it('returns correct routing headers for google', async () => {
+    const headers = await getProviderHeaders('google');
     expect(headers['X-Api-Provider']).toBe('google');
     expect(headers['X-Api-Auth-Header']).toBe('Authorization');
     expect(headers['X-Proxy-Target-Url']).toBe('https://generativelanguage.googleapis.com');
   });
 
-  it('throws when the provider is not found', () => {
-    expect(() => getProviderHeaders('unknown-provider')).toThrow(
+  it('throws when the provider is not found', async () => {
+    await expect(getProviderHeaders('unknown-provider')).rejects.toThrow(
       'Provider "unknown-provider" not found.'
     );
+  });
+
+  it('uses the default local base URL when no custom setting is stored', async () => {
+    mockInvoke.mockResolvedValue([]); // getSetting -> dbSelectOne -> no row
+    const headers = await getProviderHeaders('local');
+    expect(headers['X-Api-Provider']).toBe('local');
+    expect(headers['X-Proxy-Target-Url']).toBe('http://127.0.0.1:11434');
+  });
+
+  it('uses the stored custom base URL for the local provider when one is set', async () => {
+    mockInvoke.mockResolvedValue([{ key: 'local_provider_base_url', value: 'http://192.168.1.50:1234' }]);
+    const headers = await getProviderHeaders('local');
+    expect(headers['X-Proxy-Target-Url']).toBe('http://192.168.1.50:1234');
   });
 });
 


### PR DESCRIPTION
Adds a fourth provider (Ollama, LM Studio, vLLM, or any OpenAI-compatible server) alongside OpenAI/Anthropic/Google.

No provider-specific backend changes needed — the existing local proxy (`server.rs`) already forwards generically via `X-Proxy-Target-Url`/`X-Api-Provider`/`X-Api-Auth-Header`, and skips attaching an auth header when no `api_keys` row exists for a provider — exactly what an unauthenticated local server needs.

- `src/constants/providers.ts`: new `LOCAL` entry, defaults to `http://127.0.0.1:11434`.
- Settings → API Keys: new "Local Endpoint" field to override the base URL per-user (stored via the existing `settings` table, not `api_keys`, since it's a URL not a secret).
- `getProviderHeaders()` is now async to read the override; all 6 call sites updated to resolve headers before constructing the model.

Full test suite (568 tests) and `tsc --noEmit` pass. New tests cover default vs. overridden local base URL resolution.