### PR TITLE
Refresh provider model catalogs

### DIFF
--- a/src/features/Agents/MainContent/Test/JudgeModelSelect.tsx
+++ b/src/features/Agents/MainContent/Test/JudgeModelSelect.tsx
@@ -14,31 +14,6 @@ type ProviderModelOptions = Record<
   { label: string; models: { value: string; label: string }[] }
 >;
 
-const FALLBACK_OPTIONS: ProviderModelOptions = {
-  openai: {
-    label: "OpenAI",
-    models: [
-      { value: "gpt-4o-mini", label: "gpt-4o-mini" },
-      { value: "gpt-4o", label: "gpt-4o" },
-      { value: "gpt-4.1", label: "gpt-4.1" },
-    ],
-  },
-  anthropic: {
-    label: "Anthropic",
-    models: [
-      { value: "claude-3-haiku", label: "claude-3-haiku" },
-      { value: "claude-3-5-sonnet", label: "claude-3.5-sonnet" },
-    ],
-  },
-  google: {
-    label: "Google",
-    models: [
-      { value: "gemini-2.0-flash", label: "gemini-2.0-flash" },
-      { value: "gemini-2.5-flash-lite", label: "gemini-2.5-flash-lite" },
-    ],
-  },
-};
-
 function buildOptions(
   providerModels: Record<string, { id: string; name: string }[]>
 ): ProviderModelOptions {
@@ -52,7 +27,7 @@ function buildOptions(
       result[provider.id] = { label: provider.name, models: validModels };
     }
   }
-  return Object.keys(result).length > 0 ? result : FALLBACK_OPTIONS;
+  return result;
 }
 
 interface JudgeModelSelectProps {
@@ -61,32 +36,43 @@ interface JudgeModelSelectProps {
 }
 
 export function JudgeModelSelect({ value, onChange }: JudgeModelSelectProps) {
-  const [options, setOptions] = useState<ProviderModelOptions>(FALLBACK_OPTIONS);
+  const [options, setOptions] = useState<ProviderModelOptions>({});
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    fetchAndNormalizeModels().then((providerModels) => {
-      setOptions(buildOptions(providerModels));
-    });
+    fetchAndNormalizeModels({ forceRefresh: true })
+      .then((providerModels) => {
+        setOptions(buildOptions(providerModels));
+      })
+      .finally(() => setIsLoading(false));
   }, []);
 
   const providerIds = Object.keys(options);
-  const provider = value?.provider ?? providerIds[0] ?? "openai";
-  const model = value?.model ?? options[provider]?.models[0]?.value ?? "gpt-4o-mini";
-  const currentProvider = providerIds.includes(provider) ? provider : providerIds[0] ?? "openai";
+  const provider = value?.provider ?? providerIds[0] ?? "";
+  const model = value?.model ?? options[provider]?.models[0]?.value ?? "";
+  const currentProvider = providerIds.includes(provider) ? provider : providerIds[0] ?? "";
   const models = options[currentProvider]?.models ?? [];
   const currentModel = models.some((m) => m.value === model)
     ? model
-    : models[0]?.value ?? "gpt-4o-mini";
+    : models[0]?.value ?? "";
 
   const handleProviderChange = (provider: string) => {
     const nextModels = options[provider]?.models ?? [];
-    const model = nextModels[0]?.value ?? "gpt-4o-mini";
+    const model = nextModels[0]?.value ?? "";
     onChange({ provider, model });
   };
 
   const handleModelChange = (model: string) => {
     onChange({ provider: currentProvider, model });
   };
+
+  if (providerIds.length === 0) {
+    return (
+      <p className="flex-1 text-[11px] text-slate-400">
+        {isLoading ? "Loading provider models…" : "Add an API key in Settings to select a judge model."}
+      </p>
+    );
+  }
 
   return (
     <div className="flex flex-1 items-center gap-2 min-w-0">

--- a/src/features/Scenarios/MainContent/Test/ModelsCompare.tsx
+++ b/src/features/Scenarios/MainContent/Test/ModelsCompare.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useContext } from "react";
+import { useState, useCallback, useContext, useEffect } from "react";
 import {
   Plus,
   X,
@@ -48,7 +48,7 @@ interface SlotResult {
   pass?: boolean;
 }
 
-/** Build provider/model options from context or fallback to defaults */
+/** Build provider/model options from the catalogs returned by provider APIs. */
 function buildProviderModelOptions(
   providerModels: Record<string, Array<{ id?: string; name?: string }>>
 ): Record<string, { label: string; models: { value: string; label: string }[] }> {
@@ -65,35 +65,6 @@ function buildProviderModelOptions(
         models: validModels,
       };
     }
-  }
-
-  // Fallback when providerModels is empty (e.g. before API keys configured)
-  if (Object.keys(result).length === 0) {
-    return {
-      openai: {
-        label: "OpenAI",
-        models: [
-          { value: "gpt-4o", label: "gpt-4o" },
-          { value: "gpt-4-turbo", label: "gpt-4-turbo" },
-          { value: "gpt-3.5-turbo", label: "gpt-3.5-turbo" },
-        ],
-      },
-      anthropic: {
-        label: "Anthropic",
-        models: [
-          { value: "claude-3-5-sonnet", label: "claude-3.5-sonnet" },
-          { value: "claude-3-opus", label: "claude-3-opus" },
-          { value: "claude-3-haiku", label: "claude-3-haiku" },
-        ],
-      },
-      google: {
-        label: "Google",
-        models: [
-          { value: "gemini-1.5-pro", label: "gemini-1.5-pro" },
-          { value: "gemini-1.5-flash", label: "gemini-1.5-flash" },
-        ],
-      },
-    };
   }
 
   return result;
@@ -122,15 +93,36 @@ export function ModelsCompare({ cases, providerModels }: ModelsCompareProps) {
 
   const PROVIDERS = buildProviderModelOptions(providerModels);
   const providerIds = Object.keys(PROVIDERS);
+  const isModelCatalogLoading = Object.keys(providerModels).length === 0;
 
-  const [slots, setSlots] = useState<ModelSlot[]>(() => {
+  const [slots, setSlots] = useState<ModelSlot[]>([]);
+
+  useEffect(() => {
+    if (providerIds.length === 0) {
+      setSlots([]);
+      return;
+    }
+
     const first = providerIds[0];
     const second = providerIds[1] ?? first;
-    return [
-      { id: generateId(), provider: first, model: PROVIDERS[first].models[0]?.value ?? "" },
-      { id: generateId(), provider: second, model: PROVIDERS[second].models[0]?.value ?? "" },
-    ].filter((s) => s.model);
-  });
+    setSlots((current) => {
+      if (current.length === 0) {
+        return [
+          { id: generateId(), provider: first, model: PROVIDERS[first].models[0]?.value ?? "" },
+          { id: generateId(), provider: second, model: PROVIDERS[second].models[0]?.value ?? "" },
+        ].filter((slot) => slot.model);
+      }
+
+      return current.map((slot) => {
+        const provider = PROVIDERS[slot.provider] ? slot.provider : first;
+        const models = PROVIDERS[provider].models;
+        const model = models.some((item) => item.value === slot.model)
+          ? slot.model
+          : (models[0]?.value ?? "");
+        return { ...slot, provider, model };
+      }).filter((slot) => slot.model);
+    });
+  }, [providerModels]);
 
   const [selectedCaseId, setSelectedCaseId] = useState<string | null>(
     cases[0]?.id ?? null
@@ -190,7 +182,7 @@ export function ModelsCompare({ cases, providerModels }: ModelsCompareProps) {
   };
 
   const runAll = useCallback(async () => {
-    if (!scenarioId || !currentScenario) return;
+    if (!scenarioId || !currentScenario || slots.length === 0) return;
 
     setIsRunning(true);
     // Reset all slots to running state immediately
@@ -330,7 +322,7 @@ export function ModelsCompare({ cases, providerModels }: ModelsCompareProps) {
     setIsRunning(false);
   };
 
-  const allDone = slots.every((s) => results[s.id]?.status === "done");
+  const allDone = slots.length > 0 && slots.every((s) => results[s.id]?.status === "done");
   const hasResults = Object.keys(results).length > 0;
 
   const bestLatency =
@@ -384,6 +376,13 @@ export function ModelsCompare({ cases, providerModels }: ModelsCompareProps) {
           </div>
 
           <div className="flex flex-1 items-center gap-2 overflow-x-auto scrollbar-thin">
+            {providerIds.length === 0 && (
+              <span className="text-xs text-text-muted">
+                {isModelCatalogLoading
+                  ? "Loading available models…"
+                  : "Add an API key in Settings to load available models."}
+              </span>
+            )}
             {slots.map((slot, idx) => (
               <div
                 key={slot.id}
@@ -443,7 +442,7 @@ export function ModelsCompare({ cases, providerModels }: ModelsCompareProps) {
                 )}
               </div>
             ))}
-            {slots.length < 4 && (
+            {providerIds.length > 0 && slots.length < 4 && (
               <button
                 onClick={addSlot}
                 className="flex h-9 w-9 items-center justify-center rounded-lg border border-dashed border-border-light text-text-muted hover:text-text-main hover:border-primary/40 transition-all"
@@ -468,7 +467,7 @@ export function ModelsCompare({ cases, providerModels }: ModelsCompareProps) {
             <Button
               size="sm"
               onClick={runAll}
-              disabled={isRunning}
+              disabled={isRunning || slots.length === 0}
               className="h-8 gap-1.5 bg-primary text-white hover:bg-primary/90 font-semibold px-4"
             >
               <Play className="h-3 w-3" />
@@ -534,6 +533,15 @@ export function ModelsCompare({ cases, providerModels }: ModelsCompareProps) {
 
       {/* Columns grid */}
       <div className="flex flex-1 overflow-hidden">
+        {slots.length === 0 && (
+          <div className="flex flex-1 items-center justify-center bg-slate-50/50">
+            <p className="text-xs text-text-muted/70">
+              {isModelCatalogLoading
+                ? "Refreshing provider catalogs…"
+                : "Model comparison becomes available after a provider catalog is loaded."}
+            </p>
+          </div>
+        )}
         {slots.map((slot, idx) => {
           const r = results[slot.id];
           const color = COLUMN_COLORS[idx];

--- a/src/features/Settings/MainContent/ApiKeys/index.tsx
+++ b/src/features/Settings/MainContent/ApiKeys/index.tsx
@@ -12,19 +12,19 @@ const PROVIDERS = [
     id: "openai",
     label: "OpenAI API Key",
     placeholder: "sk-...",
-    fallbackDescription: "Required for OpenAI chat models (GPT-4o, o1, o3, etc.).",
+    fallbackDescription: "Required for OpenAI text and reasoning models.",
   },
   {
     id: "anthropic",
     label: "Anthropic API Key",
     placeholder: "sk-ant-...",
-    fallbackDescription: "Required for Claude models (Claude 3.5 Sonnet, Opus, etc.).",
+    fallbackDescription: "Required for Anthropic Claude models.",
   },
   {
     id: "google",
     label: "Google Vertex/Gemini API Key",
     placeholder: "Enter Google Cloud API Key",
-    fallbackDescription: "Required for Google Gemini models (Gemini 1.5 Pro, Flash, etc.).",
+    fallbackDescription: "Required for Google Gemini models.",
   },
 ] as const;
 
@@ -94,6 +94,8 @@ function ApiKeys() {
           query: { where: { provider } },
         });
         clearModelCache();
+        const models = await fetchAndNormalizeModels({ forceRefresh: true });
+        setProviderModels(models);
       } catch (error) {
         console.error(`Failed to delete API key for ${provider}:`, error);
         setSaveStatus((prev) => ({ ...prev, [provider]: "error" }));
@@ -119,6 +121,8 @@ function ApiKeys() {
       }
       clearModelCache();
       setApiKeys((prev) => ({ ...prev, [provider]: apiKey }));
+      const models = await fetchAndNormalizeModels({ forceRefresh: true });
+      setProviderModels(models);
       setSaveStatus((prev) => ({ ...prev, [provider]: "saved" }));
 
       setTimeout(() => {

--- a/src/hooks/useProviderModels.ts
+++ b/src/hooks/useProviderModels.ts
@@ -7,7 +7,9 @@ export function useProviderModels(): ProviderModels {
   const [providerModels, setProviderModels] = useState<ProviderModels>({});
 
   useEffect(() => {
-    fetchAndNormalizeModels().then(setProviderModels);
+    // Refresh once when a model-consuming screen mounts. If a provider is
+    // temporarily unavailable, modelManager returns its last-known-good list.
+    fetchAndNormalizeModels({ forceRefresh: true }).then(setProviderModels);
   }, []);
 
   return providerModels;

--- a/src/lib/gateway/index.ts
+++ b/src/lib/gateway/index.ts
@@ -159,28 +159,44 @@ export const streamText = async (
 export const listModels = async (providerId: string): Promise<any[]> => {
   const modelsUrl = getProviderModelsUrl(providerId);
   try {
-    const response = await fetch(modelsUrl, {
-      method: 'GET',
-      headers: getProviderHeaders(providerId),
-    });
+    const models: any[] = [];
+    let nextUrl: string | null = modelsUrl;
 
-    if (!response.ok) {
-      console.log(response)
-      const errorText = await response.text();
-      throw new Error(`Failed to fetch models from ${providerId}: ${response.status} ${errorText}`);
+    // Anthropic's models endpoint is cursor-paginated. OpenAI and Google's
+    // OpenAI-compatible endpoint currently return their catalog in one page.
+    while (nextUrl) {
+      const response = await fetch(nextUrl, {
+        method: 'GET',
+        headers: getProviderHeaders(providerId),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Failed to fetch models from ${providerId}: ${response.status} ${errorText}`);
+      }
+
+      const data = await response.json();
+      if (data && Array.isArray(data.data)) {
+        models.push(...data.data);
+      } else if (data && Array.isArray(data.models)) {
+        models.push(...data.models);
+      } else if (Array.isArray(data)) {
+        models.push(...data);
+      } else {
+        throw new Error(`Unexpected response format from ${providerId} models API.`);
+      }
+
+      if (providerId === 'anthropic' && data?.has_more && data?.last_id) {
+        const url = new URL(modelsUrl);
+        url.searchParams.set('after_id', data.last_id);
+        url.searchParams.set('limit', '100');
+        nextUrl = url.toString();
+      } else {
+        nextUrl = null;
+      }
     }
 
-    const data = await response.json();
-    // Return the array as returned from the API
-    if (data && Array.isArray(data.data)) {
-      return data.data;
-    } else if (data && Array.isArray(data.models)) {
-      return data.models;
-    } else if (Array.isArray(data)) {
-      return data;
-    }
-
-    throw new Error(`Unexpected response format from ${providerId} models API.`);
+    return models;
 
   } catch (error) {
     console.error(`Error listing models for ${providerId}:`, error);

--- a/src/lib/modelManager.ts
+++ b/src/lib/modelManager.ts
@@ -32,25 +32,42 @@ interface ProviderModels {
 interface AllModelCache {
   data: ProviderModels;
   timestamp: number;
+  providerTimestamps?: Record<string, number>;
 }
+
+interface ProviderFetchResult {
+  providerId: string;
+  models?: any[];
+}
+
+const pendingProviderRequests = new Map<string, Promise<any[]>>();
+
+const fetchProviderModels = (providerId: string): Promise<any[]> => {
+  const pending = pendingProviderRequests.get(providerId);
+  if (pending) return pending;
+
+  const request = listModels(providerId).finally(() => {
+    pendingProviderRequests.delete(providerId);
+  });
+  pendingProviderRequests.set(providerId, request);
+  return request;
+};
 
 /**
  * Fetches raw model lists for ALL providers from the API and constructs an AllModelCache object.
  * This function does NOT use caching internally; it always fetches fresh data.
  * @returns A Promise resolving to an AllModelCache object.
  */
-const fetchRawModels = async (): Promise<AllModelCache> => {
-  const providerModelsData: ProviderModels = {};
-  for (const provider of PROVIDERS_LIST) {
+const fetchRawModels = async (providerIds: string[]): Promise<ProviderFetchResult[]> => {
+  return Promise.all(providerIds.map(async (providerId) => {
+    const provider = PROVIDERS_LIST.find((item) => item.id === providerId);
     try {
-      const rawModels = await listModels(provider.id);
-      providerModelsData[provider.id] = rawModels;
+      return { providerId, models: await fetchProviderModels(providerId) };
     } catch (error) {
-      console.error(`Failed to fetch raw models for provider ${provider.name}:`, error);
-      providerModelsData[provider.id] = [];
+      console.error(`Failed to fetch raw models for provider ${provider?.name ?? providerId}:`, error);
+      return { providerId };
     }
-  }
-  return { data: providerModelsData, timestamp: Date.now() };
+  }));
 }
 
 /**
@@ -58,15 +75,13 @@ const fetchRawModels = async (): Promise<AllModelCache> => {
  * It fetches fresh data for all providers if the cache is expired or missing.
  * @returns A Promise resolving to an AllModelCache object (from cache or newly fetched).
  */
-const getAllModels = async (): Promise<ProviderModels> => {
+const getAllModels = async (forceRefresh = false): Promise<ProviderModels> => {
   const allCacheString = localStorage.getItem(CACHE_KEY);
   let cachedData: AllModelCache = { data: {}, timestamp: 0 };
-  let cacheIsFresh = false;
 
   if (allCacheString) {
     try {
       cachedData = JSON.parse(allCacheString);
-      cacheIsFresh = (Date.now() - cachedData.timestamp < CACHE_DURATION);
     } catch (e) {
       console.error(`Failed to parse all models cache from localStorage:`, e);
       localStorage.removeItem(CACHE_KEY);
@@ -74,25 +89,53 @@ const getAllModels = async (): Promise<ProviderModels> => {
     }
   }
 
-  if (cacheIsFresh) return cachedData.data;
+  const now = Date.now();
+  const providersToFetch = PROVIDERS_LIST
+    .filter((provider) => {
+      if (forceRefresh || !cachedData.data[provider.id]) return true;
+      const timestamp = cachedData.providerTimestamps
+        ? (cachedData.providerTimestamps[provider.id] ?? 0)
+        : cachedData.timestamp;
+      return now - timestamp >= CACHE_DURATION;
+    })
+    .map((provider) => provider.id);
+
+  if (providersToFetch.length === 0) return cachedData.data;
 
   try {
-    const newRawProviderModels = await fetchRawModels();
+    const results = await fetchRawModels(providersToFetch);
+    const dataToCache: ProviderModels = { ...cachedData.data };
+    const providerTimestamps = { ...cachedData.providerTimestamps };
+    let cacheChanged = false;
 
-    // Only persist providers that actually returned models.
-    // Empty results mean "no API key yet" — caching them would lock out a
-    // provider for the full TTL even after the user adds a key.
-    const dataToCache: ProviderModels = {};
-    for (const [providerId, models] of Object.entries(newRawProviderModels.data)) {
-      if (Array.isArray(models) && models.length > 0) {
+    for (const { providerId, models } of results) {
+      // A missing `models` value is a failed request. Preserve the provider's
+      // last-known-good catalog and leave its timestamp stale so it is retried.
+      if (!models) continue;
+
+      cacheChanged = true;
+      if (models.length > 0) {
         dataToCache[providerId] = models;
+        providerTimestamps[providerId] = now;
+      } else {
+        delete dataToCache[providerId];
+        delete providerTimestamps[providerId];
       }
     }
-    if (Object.keys(dataToCache).length > 0) {
-      localStorage.setItem(CACHE_KEY, JSON.stringify({ data: dataToCache, timestamp: Date.now() }));
+
+    if (cacheChanged) {
+      if (Object.keys(dataToCache).length > 0) {
+        localStorage.setItem(CACHE_KEY, JSON.stringify({
+          data: dataToCache,
+          timestamp: now,
+          providerTimestamps,
+        }));
+      } else {
+        localStorage.removeItem(CACHE_KEY);
+      }
     }
 
-    return newRawProviderModels.data;
+    return dataToCache;
   } catch (error) {
     console.error(`Failed to fetch and cache all raw models:`, error);
     if (Object.keys(cachedData.data).length > 0) {
@@ -199,11 +242,13 @@ export function clearModelCache(): void {
  * Fetches and normalizes all models for all providers.
  * @returns A Promise resolving to a record of provider IDs to arrays of normalized model objects.
  */
-export const fetchAndNormalizeModels = async (): Promise<Record<string, { id: string; name: string }[]>> => {
+export const fetchAndNormalizeModels = async (
+  options: { forceRefresh?: boolean } = {}
+): Promise<Record<string, { id: string; name: string }[]>> => {
   const allNormalizedModels: Record<string, { id: string; name: string }[]> = {};
 
   try {
-    const allRawModelCache = await getAllModels();
+    const allRawModelCache = await getAllModels(options.forceRefresh);
 
     for (const provider of PROVIDERS_LIST) {
       const providerModels = allRawModelCache[provider.id];

--- a/tests/lib/gateway/index.test.ts
+++ b/tests/lib/gateway/index.test.ts
@@ -186,6 +186,41 @@ describe('listModels', () => {
     expect(result).toEqual(models);
   });
 
+  it('collects every page from Anthropic\'s cursor-paginated response', async () => {
+    (fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({
+          data: [{ id: 'claude-opus-5' }],
+          has_more: true,
+          last_id: 'claude-opus-5',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({
+          data: [{ id: 'claude-sonnet-5' }],
+          has_more: false,
+          last_id: 'claude-sonnet-5',
+        }),
+      });
+
+    const result = await listModels('anthropic');
+
+    expect(result).toEqual([
+      { id: 'claude-opus-5' },
+      { id: 'claude-sonnet-5' },
+    ]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect((fetch as ReturnType<typeof vi.fn>).mock.calls[1][0]).toContain(
+      'after_id=claude-opus-5'
+    );
+  });
+
   it('returns data.models when the response has a models array', async () => {
     const models = [{ id: 'gemini-pro' }];
     mockFetch({ models });

--- a/tests/lib/modelManager.test.ts
+++ b/tests/lib/modelManager.test.ts
@@ -64,6 +64,19 @@ describe('fetchAndNormalizeModels — cache behaviour', () => {
     expect(mockListModels).not.toHaveBeenCalled();
   });
 
+  it('bypasses a fresh cache when a refresh is requested', async () => {
+    seedCache({ openai: [{ id: 'gpt-5' }], anthropic: [{ id: 'claude-opus-4-6' }] });
+    mockListModels
+      .mockResolvedValueOnce([{ id: 'gpt-5.2' }])
+      .mockResolvedValueOnce([{ id: 'claude-opus-5' }]);
+
+    const result = await fetchAndNormalizeModels({ forceRefresh: true });
+
+    expect(mockListModels).toHaveBeenCalledTimes(2);
+    expect(result.openai.map((model) => model.id)).toContain('gpt-5.2');
+    expect(result.anthropic.map((model) => model.id)).toContain('claude-opus-5');
+  });
+
   it('fetches when cache is stale (older than 1 hour)', async () => {
     store[CACHE_KEY] = JSON.stringify({
       data: { openai: [{ id: 'gpt-5' }] },
@@ -101,6 +114,25 @@ describe('fetchAndNormalizeModels — cache behaviour', () => {
     await fetchAndNormalizeModels();
 
     expect(mockListModels).toHaveBeenCalled();
+  });
+
+  it('preserves a provider\'s last-known-good models when only its refresh fails', async () => {
+    seedCache({ openai: [{ id: 'gpt-5' }], anthropic: [{ id: 'claude-opus-4-6' }] });
+    mockListModels
+      .mockResolvedValueOnce([{ id: 'gpt-5.2' }])
+      .mockRejectedValueOnce(new Error('anthropic unavailable'));
+
+    const result = await fetchAndNormalizeModels({ forceRefresh: true });
+
+    expect(result.openai.map((model) => model.id)).toContain('gpt-5.2');
+    expect(result.anthropic.map((model) => model.id)).toContain('claude-opus-4-6');
+
+    mockListModels.mockClear();
+    mockListModels.mockRejectedValueOnce(new Error('anthropic still unavailable'));
+    await fetchAndNormalizeModels();
+
+    expect(mockListModels).toHaveBeenCalledTimes(1);
+    expect(mockListModels).toHaveBeenCalledWith('anthropic');
   });
 });
 


### PR DESCRIPTION
Refreshes model catalogs from the configured OpenAI, Anthropic, and Gemini APIs when model screens mount or API keys change, including Anthropic pagination. Removes stale embedded fallback options from comparison and judge selectors in favor of loading and setup states. Adds per-provider cache timestamps, in-flight request deduplication, and last-known-good fallback behavior so one provider outage does not erase other catalogs. Validated with `bun run test` (569 tests) and `bun run build`.